### PR TITLE
fix handling of server-deletes resulting in 404s

### DIFF
--- a/restapi/api_object.go
+++ b/restapi/api_object.go
@@ -285,7 +285,7 @@ func (obj *APIObject) readObject() error {
 
 	resultString, err := obj.apiClient.sendRequest(obj.readMethod, strings.Replace(getPath, "{id}", obj.id, -1), "")
 	if err != nil {
-		if strings.Contains(err.Error(), "Unexpected response code '404'") {
+		if strings.Contains(err.Error(), "unexpected response code '404'") {
 			log.Printf("api_object.go: 404 error while refreshing state for '%s' at path '%s'. Removing from state.", obj.id, obj.getPath)
 			obj.id = ""
 			return nil

--- a/restapi/api_object_test.go
+++ b/restapi/api_object_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	"github.com/Mastercard/terraform-provider-restapi/fakeserver"
@@ -220,11 +219,8 @@ func TestAPIObject(t *testing.T) {
 		}
 		testingObjects["pet"].deleteObject()
 		err = testingObjects["pet"].readObject()
-		if err == nil {
-			t.Fatalf("api_object_test.go: 'pet' object deleted, but a subsequent read did not return an error!\n")
-		}
-		if !strings.Contains(err.Error(), "404") {
-			t.Fatalf("api_object_test.go: 'pet' object deleted, but the resulting error was not a 404 during read! What came back was: %v\n", err)
+		if err != nil {
+			t.Fatalf("api_object_test.go: 'pet' object deleted, but an error was returned when reading the object (expected the provider to cope with this!\n")
 		}
 	})
 


### PR DESCRIPTION
<a name="start-layerci-do-not-edit-between-tags"></a>

<div>
<a href="https://webapp.io/novboy?utm_source=pr-logo"><img src="https://webapp.io/static/logo/logodarkwithtext.svg" width="auto" height="15px" alt=""/></a>
<img src="https://webapp.io/static/images/transparent.png" width="10px" height="1px" alt=""/>
<a href="https://webapp.io/novboy?utm_source=pr-finish-installation"><b>Finish webapp.io installation</b></a>
<img src="https://webapp.io/static/images/transparent.png" width="10px" height="1px" alt=""/>
<a href="https://webapp.io/docs"><b>Read docs</b></a>
</div>

<hr>

<a href="https://webapp.io/novboy?utm_source=pr-screenshot"><img alt="Screenshot of main page" align="right" height="175px" width="175px" src="https://i.imgur.com/nseGEwE.png"/></a>

<h3>webapp.io steps</h3>

<a href="https://webapp.io/novboy?utm_source=pr-backend-build"><img src="https://webapp.io/static/images/check-circle-crop.png" width="17px"> Backend build</a>
<a href="https://webapp.io/novboy?utm_source=pr-frontend-build"><img src="https://webapp.io/static/images/check-circle-crop.png" width="17px"> Frontend build</a>
<a href="https://webapp.io/novboy?utm_source=preview-environment"><img src="https://webapp.io/static/images/check-circle-crop.png" width="17px"> Preview environment</a>
<a href="https://webapp.io/novboy?utm_source=e2e-tests"><img src="https://webapp.io/static/images/check-circle-crop.png" width="17px"> E2E tests</a>

<hr>

<a href="https://webapp.io/">Click here to configure this template</a>

<a name="end-layerci-do-not-edit-between-tags"></a>